### PR TITLE
Update security.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,49 @@
 # Security Policy
 
+This security policy outlines procedures for reporting vulnerabilities, coordinating fixes, and disclosing security issues in Cloud Native Buildpacks projects.
+
 ## Reporting a Vulnerability
 
 We strongly encourage people to report security vulnerabilities privately to our security team before disclosing them in a public forum.
 
-Please note that the e-mail address below should only be used for reporting undisclosed security vulnerabilities in Cloud Native Buildpacks products and managing the process of fixing such vulnerabilities. We cannot accept regular bug reports or other security related queries at this address.
+There are two ways to report a vulnerability:
 
-The e-mail address to use to contact the Cloud Native Buildpacks Security Team is security@buildpacks.io.
+1. **GitHub Security Advisories**: Use the [Report a vulnerability](https://github.com/buildpacks/community/security/advisories/new) feature in the Security tab of the `buildpacks/community` repository.
+2. **Email**: Send a report to [security@buildpacks.io](mailto:security@buildpacks.io).
 
-The fingerprint is: `7AA4 452E A0C3 56F8 894D C869 4E56 F857 5412 6F64`
+The PGP fingerprint for the security email is: `7AA4 452E A0C3 56F8 894D C869 4E56 F857 5412 6F64`
 
 It can be obtained from a public key server such as pgp.mit.edu.
+
+Please note that these channels should only be used for reporting undisclosed security vulnerabilities in Cloud Native Buildpacks products. We cannot accept regular bug reports or other security-related queries through these channels.
+
+### What to Include in a Report
+
+To help us triage and respond quickly, please include as much of the following as possible:
+
+- Affected software and versions
+- Steps to reproduce the vulnerability
+- Description of the impact or potential consequences
+- Suggested severity (e.g., low, medium, high, critical)
+- Any relevant logs, screenshots, or proof-of-concept code
+
+## Response Process
+
+1. **Acknowledgment**: The security team will acknowledge receipt of your report within 72 hours.
+2. **Triage**: A maintainer will be assigned to investigate and validate the issue. If additional information is needed, they will reach out to the reporter directly.
+3. **Advisory Draft**: Once confirmed, the maintainers will create a draft GitHub Security Advisory to coordinate discussion with the reporter and relevant maintainers.
+4. **Fix Development**: A fix will be developed privately. A timeline for the patch and disclosure date will be agreed upon with the reporter.
+5. **Disclosure**: Once the fix is released, the security advisory will be published and the vulnerability disclosed publicly through GitHub Security Advisories and project release notes.
+
+We aim to resolve confirmed vulnerabilities promptly and will keep reporters informed throughout the process.
+
+## Supported Versions
+
+Security fixes are applied to the latest release of each Cloud Native Buildpacks project. Users are encouraged to stay on the most recent release to receive security updates.
+
+## Public Disclosure
+
+Resolved vulnerabilities are disclosed through:
+
+- [GitHub Security Advisories](https://github.com/buildpacks/community/security/advisories)
+- Release notes for the affected project


### PR DESCRIPTION
This pull request significantly expands and clarifies the `SECURITY.md` file to provide a comprehensive security policy for Cloud Native Buildpacks projects. The update introduces detailed instructions for reporting vulnerabilities, outlines the response process, specifies supported versions, and explains public disclosure practices.

Security reporting and process improvements:

* Added clear instructions for reporting vulnerabilities via GitHub Security Advisories or email, including updated contact information and PGP fingerprint.
* Introduced a section detailing what information to include in a vulnerability report to facilitate efficient triage and response.
* Outlined the step-by-step response process for handling security reports, from acknowledgment to public disclosure.

Policy and disclosure clarifications:

* Specified that security fixes are applied only to the latest release and encouraged users to stay updated for security patches.
* Clarified public disclosure practices, including use of GitHub Security Advisories and release notes for resolved vulnerabilities.


@jkutner or @hone - Someone will need to enable being able to publish https://github.com/buildpacks/community/security/advisories/new OR we can remove that avenue if we want.


References: https://github.com/buildpacks/community/issues/284